### PR TITLE
Modify DWIW plugin to return app as first parameter to route sub.

### DIFF
--- a/lib/Dancer2/Plugin/Auth/HTTP/Basic/DWIW.pm
+++ b/lib/Dancer2/Plugin/Auth/HTTP/Basic/DWIW.pm
@@ -149,7 +149,7 @@ Defaults to "Please login".
 
 =head1 ACCESSING THE APP INSTANCE
 
-Where you are using the handler, the first element of @_ will contain an instance of `'Dancer2::Plugin::Auth::HTTP::Basic::DWIW` rather than an instance of `Dancer2::Core::App`. If you need to access the instance of `Dancer2::Core::App` within a sub, instead of:
+Where you are using the handler, the first element of @_ will contain an instance of C<Dancer2::Plugin::Auth::HTTP::Basic::DWIW> rather than an instance of C<Dancer2::Core::App>. If you need to access the instance of C<Dancer2::Core::App> within a sub, instead of:
 
     sub /something => sub {
         my $app = shift;

--- a/lib/Dancer2/Plugin/Auth/HTTP/Basic/DWIW.pm
+++ b/lib/Dancer2/Plugin/Auth/HTTP/Basic/DWIW.pm
@@ -47,7 +47,7 @@ register http_basic_auth => sub {
         };
 
         unless ($@) {
-            return $sub->($dsl, @other_stuff);
+            return $sub->($dsl->app, $dsl, @other_stuff);
         }
         else {
             my $error_code = ${$@};
@@ -146,21 +146,6 @@ The realm presented by browsers in the login dialog.
 Defaults to "Please login".
 
 =back
-
-=head1 ACCESSING THE APP INSTANCE
-
-Where you are using the handler, the first element of @_ will contain an instance of C<Dancer2::Plugin::Auth::HTTP::Basic::DWIW> rather than an instance of C<Dancer2::Core::App>. If you need to access the instance of C<Dancer2::Core::App> within a sub, instead of:
-
-    sub /something => sub {
-        my $app = shift;
-    }
-
-You will need to write:
-
-    sub /something => http_basic_auth required => sub {
-        my $self = shift;
-        my $app = $self->app;
-    }
 
 =head1 OTHER
 

--- a/lib/Dancer2/Plugin/Auth/HTTP/Basic/DWIW.pm
+++ b/lib/Dancer2/Plugin/Auth/HTTP/Basic/DWIW.pm
@@ -147,6 +147,21 @@ Defaults to "Please login".
 
 =back
 
+=head1 ACCESSING THE APP INSTANCE
+
+Where you are using the handler, the first element of @_ will contain an instance of `'Dancer2::Plugin::Auth::HTTP::Basic::DWIW` rather than an instance of `Dancer2::Core::App`. If you need to access the instance of `Dancer2::Core::App` within a sub, instead of:
+
+    sub /something => sub {
+        my $app = shift;
+    }
+
+You will need to write:
+
+    sub /something => http_basic_auth required => sub {
+        my $self = shift;
+        my $app = $self->app;
+    }
+
 =head1 OTHER
 
 This is my first perl module published on CPAN. Please don't hurt me when it is bad and feel free to make suggestions or to fork it on GitHub.

--- a/t/06-can-access-app.t
+++ b/t/06-can-access-app.t
@@ -1,0 +1,30 @@
+use Test::More tests => 1;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package TestCanAccessAppInstance;
+
+    use Data::Dumper;
+    use Dancer2;
+    use Dancer2::Plugin::Auth::HTTP::Basic::DWIW;
+
+    http_basic_auth_handler check_login => sub {
+        my ($user, $pass) = @_;
+
+        return $user eq 'foo' && $pass eq 'bar';
+    };
+
+    get '/' => http_basic_auth required => sub {
+        my $app = shift;
+
+        return ref $app;
+    };
+}
+
+my $test = Plack::Test->create(TestCanAccessAppInstance->to_app);
+my $res = $test->request(
+    HTTP::Request->new('GET', '/', ['Authorization', 'Basic Zm9vOmJhcg=='])
+);
+
+is($res->content, 'Dancer2::Core::App', '[Checked first argument] First argument returned to sub is Dancer2::Core::App');

--- a/t/06-can-access-app.t
+++ b/t/06-can-access-app.t
@@ -5,7 +5,6 @@ use HTTP::Request::Common;
 {
     package TestCanAccessAppInstance;
 
-    use Data::Dumper;
     use Dancer2;
     use Dancer2::Plugin::Auth::HTTP::Basic::DWIW;
 


### PR DESCRIPTION
It's quite common to need to access the `Dancer2::Core::App` object within a route sub, so I just added an explanation for how to do this on handled routes.

Great module btw, very easy to understand.